### PR TITLE
remove 2>&1 from perf stat to display errors

### DIFF
--- a/cpucache
+++ b/cpucache
@@ -85,7 +85,7 @@ perf stat -e cycles -e cycles \
 	-e L1-dcache-loads -e L1-dcache-load-misses \
 	-e l2_rqsts.references -e l2_rqsts.miss \
 	-e r4f2e -e r412e -e instructions \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%-10s %-10s %5s %-9s %-9s %5s %-8s %-8s %5s %-8s %-8s %5s",
 		"CYCLES", "INSTR", "IPC", "L1DREF", "L1DMISS", "L1D%",

--- a/icache
+++ b/icache
@@ -79,7 +79,7 @@ fi
 # the r4f2e and r412e counters are from the architectural set, so should be stable
 echo "All counter columns are x 1000"
 perf stat -e instructions,L1-icache-load-misses,r2424,r4424,cache-references,cache-misses \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%-10s %10s %5s %9s %9s %5s %8s %8s %5s",
 			"INS", "L1IMISS", "L1I%", "L2IHIT", "L2IMISS", "L2I%",

--- a/pmcarch
+++ b/pmcarch
@@ -77,7 +77,7 @@ fi
 perf stat -e cycles -e cycles \
 	-e r4f2e -e r412e \
 	-e r00c4 -e r00c5 -e instructions \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%-10s %-10s %5s %-12s %-10s %5s %-11s %-10s %5s",
 		"K_CYCLES", "K_INSTR", "IPC", "BR_RETIRED", "BR_MISPRED", "BMR%",

--- a/pmcipc
+++ b/pmcipc
@@ -77,7 +77,7 @@ fi
 # only three (<=4) PMCs are used to workaround another issue.
 # the raw counters are from the architectural set, so should be stable.
 perf stat -e cycles -e cycles -e instructions \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%-10s %-10s %5s", "K_CYCLES", "K_INSTR", "IPC");
 		print htxt

--- a/resstalls
+++ b/resstalls
@@ -79,7 +79,7 @@ fi
 # the r4f2e and r412e counters are from the architectural set, so should be stable
 echo "All counter columns are x 1000000"
 perf stat -e resource_stalls.any,r02a2,r04a2,r08a2,r10a2,r20a2,r40a2,r80a2 \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%8s %8s %8s %8s %8s %8s %8s %8s %8s",
 			"ALL", "LOAD", "PIPE", "STORE", "ROB", "FLOAT",

--- a/tlbstat
+++ b/tlbstat
@@ -89,7 +89,7 @@ perf stat -e cycles -e cycles \
 	-e dtlb_store_misses.walk_active \
 	-e itlb_misses.walk_active \
 	-e instructions \
-	-I $(( secs * 1000 )) $target 2>&1 | awk -v hlines=$hlines '
+	-I $(( secs * 1000 )) $target | awk -v hlines=$hlines '
 	BEGIN {
 		htxt = sprintf("%-10s %-10s %5s %-10s %-10s %-10s %-10s %5s %5s",
 		"K_CYCLES", "K_INSTR", "IPC", "DTLB_WALKS", "ITLB_WALKS",


### PR DESCRIPTION
Redirecting stderr to stdout causes perf errors to be redirected to awk as normal stdin input. Then, awk silently discards them. This makes it hard to troubleshoot issues like unavailable counters or system configuration.

I had to remove '2>&1' manually from all scripts to troubleshoot silent termination with no errors. Turns out one metric was not available for my system and that causes 'perf stat' to terminate immediately. I think there's no reason to silence errors. When the script works fine, there's no error output and it works equally well.